### PR TITLE
Fix export in fetch plus plus type def

### DIFF
--- a/packages/fetch-plus-plus/index.d.ts
+++ b/packages/fetch-plus-plus/index.d.ts
@@ -19,4 +19,4 @@ declare function fetchPlusPlus(
   url: Request['url'],
   options?: RequestInit & ExtendedOptions
 ): Promise<any>
-export default fetchPlusPlus
+export = fetchPlusPlus


### PR DESCRIPTION
<!-- Explain the changes included in this PR and why are relevant or what problem does it solve. -->

By using `export default fetchPlusPlus` in the `index.d.ts` type definition, we're indicating that `fetch-plus-plus` is exported as a ESM module. While in runtime it works, by using this package in `commonJs` with pure JS, the IDE shows the following error

![image](https://github.com/bloq/js-packages/assets/352474/6d067f2e-29b5-45d0-9b47-11650f0e2c72)

Reverting the change to use what's recommended to indicate a `commonjs` export. Now the IDE shows

![image](https://github.com/bloq/js-packages/assets/352474/5b58b1e6-599e-422e-82a2-8040079a7ace)


Again, no change to runtime code (Which already worked)

### Process checklist

- [ ] Manual tests passed or not applicable.
- [ ] Automated tests added or not applicable.
- [ ] Documentation updated or not required.

### Metrics

<!-- Add the actual effort spent working in this PR.
Use hours or days as appropriate.
Consider 0.5h as the lower limit. -->

Actual effort: 0.5h
