### PR TITLE
Add repository in fetch++ package.json

### DIFF
--- a/packages/fetch-plus-plus/package.json
+++ b/packages/fetch-plus-plus/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=16"
   },
+  "repository": "bloq/js-packages",
   "scripts": {
     "coverage": "nyc npm run test",
     "test": "mocha"


### PR DESCRIPTION
<!-- Explain the changes included in this PR and why are relevant or what problem does it solve. -->

Adding the `repository` section in the `package.json` for `fetch-plus-plus` as it is missing in the published `npm package`. I am not updating the version as I won't deploy it again right now, but at least this is fixed for the next time we publish.

### Process checklist

- [ ] Manual tests passed or not applicable.
- [ ] Automated tests added or not applicable.
- [ ] Documentation updated or not required.

### Metrics

<!-- Add the actual effort spent working in this PR.
Use hours or days as appropriate.
Consider 0.5h as the lower limit. -->

Actual effort: 0.5h
